### PR TITLE
Add Navajo letterforms to vowels with ogonek accent

### DIFF
--- a/sources/Montserrat.glyphs
+++ b/sources/Montserrat.glyphs
@@ -1,14 +1,34 @@
 {
-.appVersion = "983";
+.appVersion = "1075";
 DisplayStrings = (
 "/angstrom/ydotaccent/Eldescender-cy/we-cy/Schwa.ss01/Schwa/Schwa-cy/Schwa.ss01/Schwa-cy.ss01/Schwadieresis-cy/Schwa-cy/Palochka-cy/palochka-cy/palochka-cy/Ustraitstroke-cy/Ustrait-cy/tedescender-cy/iigrave-cy/Yi-cy/I-cy/iishort-cy/ii-cy",
 "/Obarred-cy/obarred-cy/Fita-cy/fita-cy",
-"/apostrophemod/quoteleft/quoteright  /commaturnedmod"
+"/apostrophemod/quoteleft/quoteright  /commaturnedmod",
+A/ogonekcomb/Aogonek.loclNAV,
+/Aogonek.loclNAV,
+/A.ss01/Aogonek.loclNAV.ss01,
+a/ogonekcomb/aogonek.loclNAV,
+/ogonekcomb/aogonek.loclNAV,
+/aogonek.loclNAV.ss01,
+/a.sc/aogonek.loclNAV.sc,
+/aogonek.loclNAV.sc.ss01,
+/Eogonek.loclNAV,
+"",
+/E.ss01/Eogonek.loclNAV.ss01,
+/eogonek,
+/eogonek.loclNAV,
+/eogonek.loclNAV.ss01,
+/eogonek.sc,
+/e.sc/eogonek.loclNAV.sc,
+/eogonek.sc.ss01,
+/e.sc.ss01/eogonek.loclNAV.sc.ss01,
+/Uogonek.loclNAV.ss01,
+/uogonek.loclNAV.sc.ss01
 );
 classes = (
 {
 automatic = 1;
-code = "A Aacute Abreve Abreveacute Abrevedotbelow Abrevegrave Abrevehookabove Abrevetilde Acaron Acircumflex Acircumflexacute Acircumflexdotbelow Acircumflexgrave Acircumflexhookabove Acircumflextilde Adblgrave Adieresis Adotbelow Agrave Ahookabove Ainvertedbreve Amacron Aogonek Aring Aringacute Atilde AE AEacute B C Cacute Ccaron Ccedilla Ccedillaacute Ccircumflex Cdotaccent D DZcaron Eth Dcaron Dcroat Ddotbelow Dlinebelow Dzcaron E Eacute Ebreve Ecaron Ecedillabreve Ecircumflex Ecircumflexacute Ecircumflexdotbelow Ecircumflexgrave Ecircumflexhookabove Ecircumflextilde Edblgrave Edieresis Edotaccent Edotbelow Egrave Ehookabove Einvertedbreve Emacron Emacronacute Emacrongrave Eogonek Etilde Ezh Ezhcaron F G Gbreve Gcaron Gcircumflex Gcommaaccent Gdotaccent Gmacron Gstroke H Hbar Hbrevebelow Hcaron Hcircumflex Hdotbelow I IJ Iacute Ibreve Icircumflex Idblgrave Idieresis Idieresisacute Idotaccent Idotbelow Igrave Ihookabove Iinvertedbreve Imacron Iogonek Itilde J Jacute Jcircumflex K Kcaron Kcommaaccent L LJ Lacute Lcaron Lcommaaccent Ldot Ldotbelow Lj Llinebelow Lslash M Mdotbelow N NJ Nacute Ncaron Ncommaaccent Ndotaccent Ndotbelow Eng Nj Nlinebelow Ntilde O Oacute Obreve Ocircumflex Ocircumflexacute Ocircumflexdotbelow Ocircumflexgrave Ocircumflexhookabove Ocircumflextilde Odblgrave Odieresis Odieresismacron Odotaccentmacron Odotbelow Ograve Ohookabove Ohorn Ohornacute Ohorndotbelow Ohorngrave Ohornhookabove Ohorntilde Ohungarumlaut Oinvertedbreve Omacron Omacronacute Omacrongrave Oogonek Oslash Oslashacute Otilde Otildeacute Otildedieresis Otildemacron OE P Thorn Q R Racute Rcaron Rcommaaccent Rdblgrave Rdotbelow Rinvertedbreve Rlinebelow S Sacute Sacutedotaccent Saltillo Scaron Scarondotaccent Scedilla Scircumflex Scommaaccent Sdotaccent Sdotbelow Sdotbelowdotaccent Germandbls Schwa T Tbar Tcaron Tcedilla Tcommaaccent Tdotbelow Tlinebelow U Uacute Ubreve Ucaron Ucircumflex Udblgrave Udieresis Udotbelow Ugrave Uhookabove Uhorn Uhornacute Uhorndotbelow Uhorngrave Uhornhookabove Uhorntilde Uhungarumlaut Uinvertedbreve Umacron Umacrondieresis Uogonek Uring Utilde Utildeacute V W Wacute Wcircumflex Wdieresis Wgrave X Y Yacute Ycircumflex Ydieresis Ydotaccent Ydotbelow Ygrave Yhookabove Ymacron Ytilde Z Zacute Zcaron Zdotaccent Zdotbelow Iacute_J.loclNLD Adieresis.alt Udieresis.alt Udieresis.ss01.alt A.ss01 Aacute.ss01 Abreve.ss01 Abreveacute.ss01 Abrevedotbelow.ss01 Abrevegrave.ss01 Abrevehookabove.ss01 Abrevetilde.ss01 Acaron.ss01 Acircumflex.ss01 Acircumflexacute.ss01 Acircumflexdotbelow.ss01 Acircumflexgrave.ss01 Acircumflexhookabove.ss01 Acircumflextilde.ss01 Adblgrave.ss01 Adieresis.ss01 Adotbelow.ss01 Agrave.ss01 Ahookabove.ss01 Ainvertedbreve.ss01 Amacron.ss01 Aogonek.ss01 Aring.ss01 Aringacute.ss01 Atilde.ss01 AE.ss01 AEacute.ss01 DZcaron.ss01 Dzcaron.ss01 E.ss01 Eacute.ss01 Ebreve.ss01 Ecaron.ss01 Ecedillabreve.ss01 Ecircumflex.ss01 Ecircumflexacute.ss01 Ecircumflexdotbelow.ss01 Ecircumflexgrave.ss01 Ecircumflexhookabove.ss01 Ecircumflextilde.ss01 Edblgrave.ss01 Edieresis.ss01 Edotaccent.ss01 Edotbelow.ss01 Egrave.ss01 Ehookabove.ss01 Einvertedbreve.ss01 Emacron.ss01 Emacronacute.ss01 Emacrongrave.ss01 Eogonek.ss01 Etilde.ss01 F.ss01 G.ss01 Gbreve.ss01 Gcaron.ss01 Gcircumflex.ss01 Gcommaaccent.ss01 Gdotaccent.ss01 Gmacron.ss01 Gstroke.ss01 I.ss01 IJ.ss01 Iacute.ss01 Iacute_J.loclNLD.ss01 Ibreve.ss01 Icircumflex.ss01 Idblgrave.ss01 Idieresis.ss01 Idieresisacute.ss01 Idotaccent.ss01 Idotbelow.ss01 Igrave.ss01 Ihookabove.ss01 Iinvertedbreve.ss01 Imacron.ss01 Iogonek.ss01 Itilde.ss01 J.ss01 Jacute.ss01 Jcircumflex.ss01 LJ.ss01 M.ss01 Mdotbelow.ss01 N.ss01 NJ.ss01 Nacute.ss01 Ncaron.ss01 Ncommaaccent.ss01 Ndotaccent.ss01 Ndotbelow.ss01 Eng.ss01 Nj.ss01 Nlinebelow.ss01 Ntilde.ss01 Q.ss01 Schwa.ss01 T.ss01 Tbar.ss01 Tcaron.ss01 Tcedilla.ss01 Tcommaaccent.ss01 Tdotbelow.ss01 Tlinebelow.ss01 U.ss01 Uacute.ss01 Ubreve.ss01 Ucaron.ss01 Ucircumflex.ss01 Udblgrave.ss01 Udieresis.ss01 Udotbelow.ss01 Ugrave.ss01 Uhookabove.ss01 Uhorn.ss01 Uhornacute.ss01 Uhorndotbelow.ss01 Uhorngrave.ss01 Uhornhookabove.ss01 Uhorntilde.ss01 Uhungarumlaut.ss01 Uinvertedbreve.ss01 Umacron.ss01 Umacrondieresis.ss01 Uogonek.ss01 Uring.ss01 Utilde.ss01 Utildeacute.ss01 W.ss01 Wacute.ss01 Wcircumflex.ss01 Wdieresis.ss01 Wgrave.ss01 Y.ss01 Yacute.ss01 Ycircumflex.ss01 Ydieresis.ss01 Ydotaccent.ss01 Ydotbelow.ss01 Ygrave.ss01 Yhookabove.ss01 Ymacron.ss01 Ytilde.ss01 Z.ss01 Zacute.ss01 Zcaron.ss01 Zdotaccent.ss01 Zdotbelow.ss01 A-cy Be-cy Ve-cy Ge-cy Gje-cy Gheupturn-cy De-cy Ie-cy Iegrave-cy Io-cy Zhe-cy Ze-cy Ii-cy Iishort-cy Iigrave-cy Iishorttail-cy Ka-cy Kje-cy El-cy Em-cy En-cy O-cy Pe-cy Er-cy Es-cy Te-cy U-cy Ushort-cy Ef-cy Ha-cy Che-cy Tse-cy Sha-cy Shcha-cy Dzhe-cy Softsign-cy Hardsign-cy Yeru-cy Lje-cy Nje-cy Dze-cy E-cy Ereversed-cy I-cy Yi-cy Je-cy Tshe-cy Iu-cy Ia-cy Dje-cy Yat-cy Yusbig-cy Fita-cy Izhitsa-cy Ghestroke-cy Ghemiddlehook-cy Zhedescender-cy Zedescender-cy Kadescender-cy Kaverticalstroke-cy Kastroke-cy Kabashkir-cy Endescender-cy Enghe-cy Pemiddlehook-cy Pedescender-cy Haabkhasian-cy Esdescender-cy Tedescender-cy Ustrait-cy Ustraitstroke-cy Hadescender-cy Tetse-cy Chedescender-cy Cheverticalstroke-cy Shha-cy Shhadescender-cy Cheabkhasian-cy Chedescenderabkhasian-cy Palochka-cy Zhebreve-cy Kahook-cy Enhook-cy Entail-cy Chekhakassian-cy Emtail-cy Abreve-cy Adieresis-cy Aie-cy Iebreve-cy Schwa-cy Schwadieresis-cy Zhedieresis-cy Zedieresis-cy Dzeabkhasian-cy Imacron-cy Idieresis-cy Odieresis-cy Obarred-cy Obarreddieresis-cy Edieresis-cy Umacron-cy Udieresis-cy Uhungarumlaut-cy Chedieresis-cy Gedescender-cy Yerudieresis-cy Gestrokehook-cy Hahook-cy Hastroke-cy Reversedze-cy Elhook-cy Qa-cy We-cy Semisoftsign-cy Ertick-cy EnLeftHook-cy Eldescender-cy De-cy.loclBGR El-cy.loclBGR Ef-cy.loclBGR Ghestroke-cy.loclBSH Zedescender-cy.loclBSH Esdescender-cy.loclBSH Esdescender-cy.loclCHU A-cy.ss01 De-cy.ss01 Ie-cy.ss01 Iegrave-cy.ss01 Io-cy.ss01 Ii-cy.ss01 Iishort-cy.ss01 Iishorttail-cy.ss01 Iigrave-cy.ss01 El-cy.ss01 Er-cy.ss01 Te-cy.ss01 U-cy.ss01 Ushort-cy.ss01 Ef-cy.ss01 Softsign-cy.ss01 Hardsign-cy.ss01 Yeru-cy.ss01 Lje-cy.ss01 Nje-cy.ss01 Je-cy.ss01 Yat-cy.ss01 Tedescender-cy.ss01 Eltail-cy.ss01 Abreve-cy.ss01 Adieresis-cy.ss01 Aie-cy.ss01 Iebreve-cy.ss01 Schwa-cy.ss01 Schwadieresis-cy.ss01 Imacron-cy.ss01 Idieresis-cy.ss01 Umacron-cy.ss01 Udieresis-cy.ss01 Uhungarumlaut-cy.ss01 Yerudieresis-cy.ss01 Qa-cy.ss01 Semisoftsign-cy.ss01 Delta Omega angstrom kelvin";
+code = "A Aacute Abreve Abreveacute Abrevedotbelow Abrevegrave Abrevehookabove Abrevetilde Acaron Acircumflex Acircumflexacute Acircumflexdotbelow Acircumflexgrave Acircumflexhookabove Acircumflextilde Adblgrave Adieresis Adotbelow Agrave Ahookabove Ainvertedbreve Amacron Aogonek Aring Aringacute Atilde AE AEacute B C Cacute Ccaron Ccedilla Ccedillaacute Ccircumflex Cdotaccent D DZcaron Eth Dcaron Dcroat Ddotbelow Dlinebelow Dzcaron E Eacute Ebreve Ecaron Ecedillabreve Ecircumflex Ecircumflexacute Ecircumflexdotbelow Ecircumflexgrave Ecircumflexhookabove Ecircumflextilde Edblgrave Edieresis Edotaccent Edotbelow Egrave Ehookabove Einvertedbreve Emacron Emacronacute Emacrongrave Eogonek Etilde Ezh Ezhcaron F G Gbreve Gcaron Gcircumflex Gcommaaccent Gdotaccent Gmacron Gstroke H Hbar Hbrevebelow Hcaron Hcircumflex Hdotbelow I IJ Iacute Ibreve Icircumflex Idblgrave Idieresis Idieresisacute Idotaccent Idotbelow Igrave Ihookabove Iinvertedbreve Imacron Iogonek Itilde J Jacute Jcircumflex K Kcaron Kcommaaccent L LJ Lacute Lcaron Lcommaaccent Ldot Ldotbelow Lj Llinebelow Lslash M Mdotbelow N NJ Nacute Ncaron Ncommaaccent Ndotaccent Ndotbelow Eng Nj Nlinebelow Ntilde O Oacute Obreve Ocircumflex Ocircumflexacute Ocircumflexdotbelow Ocircumflexgrave Ocircumflexhookabove Ocircumflextilde Odblgrave Odieresis Odieresismacron Odotaccentmacron Odotbelow Ograve Ohookabove Ohorn Ohornacute Ohorndotbelow Ohorngrave Ohornhookabove Ohorntilde Ohungarumlaut Oinvertedbreve Omacron Omacronacute Omacrongrave Oogonek Oslash Oslashacute Otilde Otildeacute Otildedieresis Otildemacron OE P Thorn Q R Racute Rcaron Rcommaaccent Rdblgrave Rdotbelow Rinvertedbreve Rlinebelow S Sacute Sacutedotaccent Saltillo Scaron Scarondotaccent Scedilla Scircumflex Scommaaccent Sdotaccent Sdotbelow Sdotbelowdotaccent Germandbls Schwa T Tbar Tcaron Tcedilla Tcommaaccent Tdotbelow Tlinebelow U Uacute Ubreve Ucaron Ucircumflex Udblgrave Udieresis Udotbelow Ugrave Uhookabove Uhorn Uhornacute Uhorndotbelow Uhorngrave Uhornhookabove Uhorntilde Uhungarumlaut Uinvertedbreve Umacron Umacrondieresis Uogonek Uring Utilde Utildeacute V W Wacute Wcircumflex Wdieresis Wgrave X Y Yacute Ycircumflex Ydieresis Ydotaccent Ydotbelow Ygrave Yhookabove Ymacron Ytilde Z Zacute Zcaron Zdotaccent Zdotbelow Iacute_J.loclNLD Adieresis.alt Udieresis.alt Udieresis.ss01.alt Aogonek.loclNAV Eogonek.loclNAV A.ss01 Aacute.ss01 Abreve.ss01 Abreveacute.ss01 Abrevedotbelow.ss01 Abrevegrave.ss01 Abrevehookabove.ss01 Abrevetilde.ss01 Acaron.ss01 Acircumflex.ss01 Acircumflexacute.ss01 Acircumflexdotbelow.ss01 Acircumflexgrave.ss01 Acircumflexhookabove.ss01 Acircumflextilde.ss01 Adblgrave.ss01 Adieresis.ss01 Adotbelow.ss01 Agrave.ss01 Ahookabove.ss01 Ainvertedbreve.ss01 Amacron.ss01 Aogonek.ss01 Aring.ss01 Aringacute.ss01 Atilde.ss01 AE.ss01 AEacute.ss01 DZcaron.ss01 Dzcaron.ss01 E.ss01 Eacute.ss01 Ebreve.ss01 Ecaron.ss01 Ecedillabreve.ss01 Ecircumflex.ss01 Ecircumflexacute.ss01 Ecircumflexdotbelow.ss01 Ecircumflexgrave.ss01 Ecircumflexhookabove.ss01 Ecircumflextilde.ss01 Edblgrave.ss01 Edieresis.ss01 Edotaccent.ss01 Edotbelow.ss01 Egrave.ss01 Ehookabove.ss01 Einvertedbreve.ss01 Emacron.ss01 Emacronacute.ss01 Emacrongrave.ss01 Eogonek.ss01 Etilde.ss01 F.ss01 G.ss01 Gbreve.ss01 Gcaron.ss01 Gcircumflex.ss01 Gcommaaccent.ss01 Gdotaccent.ss01 Gmacron.ss01 Gstroke.ss01 I.ss01 IJ.ss01 Iacute.ss01 Iacute_J.loclNLD.ss01 Ibreve.ss01 Icircumflex.ss01 Idblgrave.ss01 Idieresis.ss01 Idieresisacute.ss01 Idotaccent.ss01 Idotbelow.ss01 Igrave.ss01 Ihookabove.ss01 Iinvertedbreve.ss01 Imacron.ss01 Iogonek.ss01 Itilde.ss01 J.ss01 Jacute.ss01 Jcircumflex.ss01 LJ.ss01 M.ss01 Mdotbelow.ss01 N.ss01 NJ.ss01 Nacute.ss01 Ncaron.ss01 Ncommaaccent.ss01 Ndotaccent.ss01 Ndotbelow.ss01 Eng.ss01 Nj.ss01 Nlinebelow.ss01 Ntilde.ss01 Q.ss01 Schwa.ss01 T.ss01 Tbar.ss01 Tcaron.ss01 Tcedilla.ss01 Tcommaaccent.ss01 Tdotbelow.ss01 Tlinebelow.ss01 U.ss01 Uacute.ss01 Ubreve.ss01 Ucaron.ss01 Ucircumflex.ss01 Udblgrave.ss01 Udieresis.ss01 Udotbelow.ss01 Ugrave.ss01 Uhookabove.ss01 Uhorn.ss01 Uhornacute.ss01 Uhorndotbelow.ss01 Uhorngrave.ss01 Uhornhookabove.ss01 Uhorntilde.ss01 Uhungarumlaut.ss01 Uinvertedbreve.ss01 Umacron.ss01 Umacrondieresis.ss01 Uogonek.ss01 Uring.ss01 Utilde.ss01 Utildeacute.ss01 W.ss01 Wacute.ss01 Wcircumflex.ss01 Wdieresis.ss01 Wgrave.ss01 Y.ss01 Yacute.ss01 Ycircumflex.ss01 Ydieresis.ss01 Ydotaccent.ss01 Ydotbelow.ss01 Ygrave.ss01 Yhookabove.ss01 Ymacron.ss01 Ytilde.ss01 Z.ss01 Zacute.ss01 Zcaron.ss01 Zdotaccent.ss01 Zdotbelow.ss01 Aogonek.loclNAV.ss01 Eogonek.loclNAV.ss01 Uogonek.loclNAV.ss01 A-cy Be-cy Ve-cy Ge-cy Gje-cy Gheupturn-cy De-cy Ie-cy Iegrave-cy Io-cy Zhe-cy Ze-cy Ii-cy Iishort-cy Iigrave-cy Iishorttail-cy Ka-cy Kje-cy El-cy Em-cy En-cy O-cy Pe-cy Er-cy Es-cy Te-cy U-cy Ushort-cy Ef-cy Ha-cy Che-cy Tse-cy Sha-cy Shcha-cy Dzhe-cy Softsign-cy Hardsign-cy Yeru-cy Lje-cy Nje-cy Dze-cy E-cy Ereversed-cy I-cy Yi-cy Je-cy Tshe-cy Iu-cy Ia-cy Dje-cy Yat-cy Yusbig-cy Fita-cy Izhitsa-cy Ghestroke-cy Ghemiddlehook-cy Zhedescender-cy Zedescender-cy Kadescender-cy Kaverticalstroke-cy Kastroke-cy Kabashkir-cy Endescender-cy Enghe-cy Pemiddlehook-cy Pedescender-cy Haabkhasian-cy Esdescender-cy Tedescender-cy Ustrait-cy Ustraitstroke-cy Hadescender-cy Tetse-cy Chedescender-cy Cheverticalstroke-cy Shha-cy Shhadescender-cy Cheabkhasian-cy Chedescenderabkhasian-cy Palochka-cy Zhebreve-cy Kahook-cy Enhook-cy Entail-cy Chekhakassian-cy Emtail-cy Abreve-cy Adieresis-cy Aie-cy Iebreve-cy Schwa-cy Schwadieresis-cy Zhedieresis-cy Zedieresis-cy Dzeabkhasian-cy Imacron-cy Idieresis-cy Odieresis-cy Obarred-cy Obarreddieresis-cy Edieresis-cy Umacron-cy Udieresis-cy Uhungarumlaut-cy Chedieresis-cy Gedescender-cy Yerudieresis-cy Gestrokehook-cy Hahook-cy Hastroke-cy Reversedze-cy Elhook-cy Qa-cy We-cy Semisoftsign-cy Ertick-cy EnLeftHook-cy Eldescender-cy De-cy.loclBGR El-cy.loclBGR Ef-cy.loclBGR Ghestroke-cy.loclBSH Zedescender-cy.loclBSH Esdescender-cy.loclBSH Esdescender-cy.loclCHU A-cy.ss01 De-cy.ss01 Ie-cy.ss01 Iegrave-cy.ss01 Io-cy.ss01 Ii-cy.ss01 Iishort-cy.ss01 Iishorttail-cy.ss01 Iigrave-cy.ss01 El-cy.ss01 Er-cy.ss01 Te-cy.ss01 U-cy.ss01 Ushort-cy.ss01 Ef-cy.ss01 Softsign-cy.ss01 Hardsign-cy.ss01 Yeru-cy.ss01 Lje-cy.ss01 Nje-cy.ss01 Je-cy.ss01 Yat-cy.ss01 Tedescender-cy.ss01 Eltail-cy.ss01 Abreve-cy.ss01 Adieresis-cy.ss01 Aie-cy.ss01 Iebreve-cy.ss01 Schwa-cy.ss01 Schwadieresis-cy.ss01 Imacron-cy.ss01 Idieresis-cy.ss01 Umacron-cy.ss01 Udieresis-cy.ss01 Uhungarumlaut-cy.ss01 Yerudieresis-cy.ss01 Qa-cy.ss01 Semisoftsign-cy.ss01 Delta Omega angstrom kelvin";
 name = Uppercase;
 }
 );
@@ -58,15 +78,15 @@ automatic = 1;
 code = "languagesystem DFLT dflt;
 languagesystem latn dflt;
 languagesystem cyrl dflt;
-languagesystem latn NLD;
-languagesystem latn CAT;
-languagesystem latn ROM;
-languagesystem latn MOL;
-languagesystem latn KAZ;
 languagesystem latn TAT;
 languagesystem latn TRK;
-languagesystem latn CRT;
+languagesystem latn MOL;
+languagesystem latn ROM;
+languagesystem latn KAZ;
 languagesystem latn AZE;
+languagesystem latn CAT;
+languagesystem latn CRT;
+languagesystem latn NLD;
 languagesystem cyrl BGR;
 languagesystem cyrl MKD;
 languagesystem cyrl SRB;
@@ -91,10 +111,10 @@ feature pnum;
 feature tnum;
 feature onum;
 feature c2sc;
+feature smcp;
 feature case;
 feature salt;
 feature ss01;
-feature smcp;
 ";
 name = aalt;
 },
@@ -229,32 +249,37 @@ name = ccmp;
 {
 automatic = 1;
 code = "script latn;
-language NLD;
-sub iacute j by iacute_j.loclNLD;
-sub Iacute J by Iacute_J.loclNLD;
-language CAT;
-sub l periodcentered' l by periodcentered.loclCAT;
-sub L periodcentered' L by periodcentered.loclCAT.case;
-language ROM;
+language TAT;
+sub i by idotaccent;
+language TRK;
+sub i by idotaccent;
+language NAV;
+sub Aogonek by Aogonek.loclNAV;
+sub Eogonek by Eogonek.loclNAV;
+sub aogonek by aogonek.loclNAV;
+sub eogonek by eogonek.loclNAV;
+language MOL;
 sub Scedilla by Scommaaccent;
 sub scedilla by scommaaccent;
 sub Tcedilla by Tcommaaccent;
 sub tcedilla by tcommaaccent;
-language MOL;
+language ROM;
 sub Scedilla by Scommaaccent;
 sub scedilla by scommaaccent;
 sub Tcedilla by Tcommaaccent;
 sub tcedilla by tcommaaccent;
 language KAZ;
 sub i by idotaccent;
-language TAT;
-sub i by idotaccent;
-language TRK;
-sub i by idotaccent;
-language CRT;
-sub i by idotaccent;
 language AZE;
 sub i by idotaccent;
+language CAT;
+sub l periodcentered' l by periodcentered.loclCAT;
+sub L periodcentered' L by periodcentered.loclCAT.case;
+language CRT;
+sub i by idotaccent;
+language NLD;
+sub iacute j by iacute_j.loclNLD;
+sub Iacute J by Iacute_J.loclNLD;
 
 script cyrl;
 language BGR;
@@ -735,6 +760,8 @@ sub Zdotaccent by zdotaccent.sc;
 sub Zdotbelow by zdotbelow.sc;
 sub Iacute_J.loclNLD by iacute_j.loclNLD.sc;
 sub Adieresis.alt by adieresis.alt.sc;
+sub Aogonek.loclNAV by aogonek.loclNAV.sc;
+sub Eogonek.loclNAV by eogonek.loclNAV.sc;
 sub exclam by exclam.sc;
 sub exclamdown by exclamdown.sc;
 sub guillemetleft by guillemetleft.sc;
@@ -1004,6 +1031,8 @@ sub zcaron by zcaron.sc;
 sub zdotaccent by zdotaccent.sc;
 sub zdotbelow by zdotbelow.sc;
 sub iacute_j.loclNLD by iacute_j.loclNLD.sc;
+sub aogonek.loclNAV by aogonek.loclNAV.sc;
+sub eogonek.loclNAV by eogonek.loclNAV.sc;
 sub exclam by exclam.sc;
 sub exclamdown by exclamdown.sc;
 sub guillemetleft by guillemetleft.sc;
@@ -1262,6 +1291,8 @@ sub Zacute by Zacute.ss01;
 sub Zcaron by Zcaron.ss01;
 sub Zdotaccent by Zdotaccent.ss01;
 sub Zdotbelow by Zdotbelow.ss01;
+sub Aogonek.loclNAV by Aogonek.loclNAV.ss01;
+sub Eogonek.loclNAV by Eogonek.loclNAV.ss01;
 sub a by a.ss01;
 sub aacute by aacute.ss01;
 sub abreve by abreve.ss01;
@@ -1324,6 +1355,8 @@ sub ldot by ldot.ss01;
 sub ldotbelow by ldotbelow.ss01;
 sub lj by lj.ss01;
 sub llinebelow by llinebelow.ss01;
+sub aogonek.loclNAV by aogonek.loclNAV.ss01;
+sub eogonek.loclNAV by eogonek.loclNAV.ss01;
 sub lslash by lslash.ss01;
 sub oe by oe.ss01;
 sub t by t.ss01;
@@ -1439,6 +1472,8 @@ sub j.sc by j.sc.ss01;
 sub jacute.sc by jacute.sc.ss01;
 sub jcircumflex.sc by jcircumflex.sc.ss01;
 sub lj.sc by lj.sc.ss01;
+sub aogonek.loclNAV.sc by aogonek.loclNAV.sc.ss01;
+sub eogonek.loclNAV.sc by eogonek.loclNAV.sc.ss01;
 sub m.sc by m.sc.ss01;
 sub mdotbelow.sc by mdotbelow.sc.ss01;
 sub n.sc by n.sc.ss01;
@@ -1729,6 +1764,8 @@ sub Zacute by Zacute.ss01;
 sub Zcaron by Zcaron.ss01;
 sub Zdotaccent by Zdotaccent.ss01;
 sub Zdotbelow by Zdotbelow.ss01;
+sub Aogonek.loclNAV by Aogonek.loclNAV.ss01;
+sub Eogonek.loclNAV by Eogonek.loclNAV.ss01;
 sub a by a.ss01;
 sub aacute by aacute.ss01;
 sub abreve by abreve.ss01;
@@ -1791,6 +1828,8 @@ sub ldot by ldot.ss01;
 sub ldotbelow by ldotbelow.ss01;
 sub lj by lj.ss01;
 sub llinebelow by llinebelow.ss01;
+sub aogonek.loclNAV by aogonek.loclNAV.ss01;
+sub eogonek.loclNAV by eogonek.loclNAV.ss01;
 sub lslash by lslash.ss01;
 sub oe by oe.ss01;
 sub t by t.ss01;
@@ -1906,6 +1945,8 @@ sub j.sc by j.sc.ss01;
 sub jacute.sc by jacute.sc.ss01;
 sub jcircumflex.sc by jcircumflex.sc.ss01;
 sub lj.sc by lj.sc.ss01;
+sub aogonek.loclNAV.sc by aogonek.loclNAV.sc.ss01;
+sub eogonek.loclNAV.sc by eogonek.loclNAV.sc.ss01;
 sub m.sc by m.sc.ss01;
 sub mdotbelow.sc by mdotbelow.sc.ss01;
 sub n.sc by n.sc.ss01;
@@ -26304,6 +26345,134 @@ rightKerningGroup = H;
 rightMetricsKey = H;
 },
 {
+color = 6;
+glyphname = Aogonek.loclNAV;
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 95, 0}";
+}
+);
+guideLines = (
+{
+angle = 90;
+position = "{344, 464}";
+}
+);
+layerId = UUID0;
+width = 688;
+},
+{
+components = (
+{
+name = A;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 205, 0}";
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 806;
+},
+{
+background = {
+components = (
+{
+name = A;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 442, 0}";
+}
+);
+};
+components = (
+{
+name = A;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 142, 0}";
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 740;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+},
+{
+color = 6;
+glyphname = Eogonek.loclNAV;
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 118, 0}";
+}
+);
+layerId = UUID0;
+width = 668;
+},
+{
+components = (
+{
+name = E;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 149, 0}";
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 673;
+},
+{
+background = {
+components = (
+{
+name = E;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 315, 0}";
+}
+);
+};
+components = (
+{
+name = E;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 135, 0}";
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 670;
+}
+);
+leftKerningGroup = H;
+rightKerningGroup = E;
+},
+{
 color = 3;
 glyphname = A.ss01;
 layers = (
@@ -41275,6 +41444,191 @@ width = 670;
 );
 leftKerningGroup = Z;
 rightKerningGroup = Z;
+},
+{
+color = 6;
+glyphname = Aogonek.loclNAV.ss01;
+layers = (
+{
+components = (
+{
+name = A.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 178, 0}";
+}
+);
+layerId = UUID0;
+width = 804;
+},
+{
+components = (
+{
+name = A.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 196, 0}";
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 792;
+},
+{
+background = {
+components = (
+{
+name = A.ss01;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 404, 0}";
+}
+);
+};
+components = (
+{
+name = A.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 202, 0}";
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 799;
+}
+);
+leftKerningGroup = A.ss01;
+rightKerningGroup = A.ss01;
+},
+{
+color = 6;
+glyphname = Eogonek.loclNAV.ss01;
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 73, 0}";
+},
+{
+name = E.ss01;
+}
+);
+layerId = UUID0;
+width = 614;
+},
+{
+components = (
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 179, 0}";
+},
+{
+name = E.ss01;
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 695;
+},
+{
+background = {
+components = (
+{
+name = E;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 315, 0}";
+}
+);
+};
+components = (
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 135, 0}";
+},
+{
+name = E.ss01;
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 649;
+}
+);
+leftKerningGroup = E.ss01;
+leftMetricsKey = "=E.ss01";
+rightKerningGroup = E.ss01;
+rightMetricsKey = "=E.ss01";
+},
+{
+color = 6;
+glyphname = Uogonek.loclNAV.ss01;
+layers = (
+{
+components = (
+{
+name = U.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 122, 0}";
+}
+);
+layerId = UUID0;
+width = 796;
+},
+{
+components = (
+{
+name = U.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 100, 0}";
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 790;
+},
+{
+background = {
+components = (
+{
+name = U.ss01;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 397, 0}";
+}
+);
+};
+components = (
+{
+name = U.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 131, 0}";
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 794;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = H;
 },
 {
 color = 2;
@@ -69057,6 +69411,130 @@ leftKerningGroup = i;
 rightKerningGroup = u;
 },
 {
+color = 6;
+glyphname = aogonek.loclNAV;
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, -16, 0}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = a;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 1, 0}";
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 639;
+},
+{
+background = {
+components = (
+{
+name = a;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 192, 0}";
+}
+);
+};
+components = (
+{
+name = a;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 11, 0}";
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 602;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = n;
+},
+{
+color = 6;
+glyphname = eogonek.loclNAV;
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 48, 0}";
+},
+{
+name = e;
+}
+);
+layerId = UUID0;
+width = 587;
+},
+{
+components = (
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 149, 0}";
+},
+{
+name = e;
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 653;
+},
+{
+background = {
+components = (
+{
+name = E;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 315, 0}";
+}
+);
+};
+components = (
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 95, 0}";
+},
+{
+name = e;
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 617;
+}
+);
+leftKerningGroup = e;
+leftMetricsKey = e;
+rightKerningGroup = e;
+rightMetricsKey = e;
+},
+{
 color = 3;
 glyphname = a.ss01;
 layers = (
@@ -75039,6 +75517,142 @@ width = 328;
 );
 leftKerningGroup = l;
 rightKerningGroup = l.ss01;
+},
+{
+color = 6;
+glyphname = aogonek.loclNAV.ss01;
+layers = (
+{
+components = (
+{
+name = a.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 41, 0}";
+}
+);
+layerId = UUID0;
+width = 671;
+},
+{
+background = {
+components = (
+{
+name = a.ss01;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 344, 0}";
+}
+);
+};
+color = -1;
+components = (
+{
+name = a.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 63, 0}";
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 700;
+},
+{
+background = {
+components = (
+{
+name = a.ss01;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 296, 0}";
+}
+);
+};
+components = (
+{
+name = a.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 69, 0}";
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 684;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = u;
+},
+{
+color = 6;
+glyphname = eogonek.loclNAV.ss01;
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 48, 0}";
+},
+{
+name = e.ss01;
+}
+);
+layerId = UUID0;
+width = 588;
+},
+{
+components = (
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 149, 0}";
+},
+{
+name = e.ss01;
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 653;
+},
+{
+background = {
+components = (
+{
+name = E;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 315, 0}";
+}
+);
+};
+components = (
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 95, 0}";
+},
+{
+name = e.ss01;
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 616;
+}
+);
+leftKerningGroup = e;
+leftMetricsKey = e.ss01;
+rightKerningGroup = e;
+rightMetricsKey = e.ss01;
 },
 {
 glyphname = lslash.ss01;
@@ -81354,6 +81968,12 @@ nodes = (
 }
 );
 };
+guideLines = (
+{
+angle = 90;
+position = "{948, 312}";
+}
+);
 layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
 paths = (
 {
@@ -84906,7 +85526,6 @@ name = eth.sc;
 }
 );
 layerId = UUID0;
-width = 713;
 userData = {
 RMXScaler = {
 adjustSpace = 18;
@@ -84914,6 +85533,7 @@ height = 80;
 width = 81;
 };
 };
+width = 713;
 },
 {
 anchors = (
@@ -84936,7 +85556,6 @@ name = eth.sc;
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 738;
 userData = {
 RMXScaler = {
 adjustSpace = 6;
@@ -84945,6 +85564,7 @@ weight = -17;
 width = 84;
 };
 };
+width = 738;
 },
 {
 anchors = (
@@ -87102,14 +87722,14 @@ nodes = (
 );
 }
 );
-width = 546;
 userData = {
 RMXScaler = {
 adjustSpace = 18;
-height = 79.8000;
+height = 79.80000;
 width = 85;
 };
 };
+width = 546;
 },
 {
 anchors = (
@@ -87160,15 +87780,15 @@ nodes = (
 );
 }
 );
-width = 594;
 userData = {
 RMXScaler = {
 adjustSpace = 6;
-height = 83.2000;
+height = 83.20000;
 weight = -24;
 width = 89;
 };
 };
+width = 594;
 },
 {
 anchors = (
@@ -87219,15 +87839,15 @@ nodes = (
 );
 }
 );
-width = 563;
 userData = {
 RMXScaler = {
 adjustSpace = 10;
-height = 81.4000;
+height = 81.40000;
 weight = -3;
 width = 86;
 };
 };
+width = 563;
 }
 );
 leftKerningGroup = ezh.sc;
@@ -88496,7 +89116,6 @@ transform = "{1, 0, 0, 1, 41, 79}";
 }
 );
 layerId = UUID0;
-width = 732;
 userData = {
 RMXScaler = {
 adjustSpace = 18;
@@ -88504,6 +89123,7 @@ height = 80;
 width = 81;
 };
 };
+width = 732;
 },
 {
 components = (
@@ -88517,7 +89137,6 @@ transform = "{1, 0, 0, 1, -62, 125}";
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 750;
 userData = {
 RMXScaler = {
 adjustSpace = 6;
@@ -88526,6 +89145,7 @@ weight = -17;
 width = 84;
 };
 };
+width = 750;
 },
 {
 background = {
@@ -91079,7 +91699,6 @@ name = k.sc;
 }
 );
 layerId = UUID0;
-width = 586;
 userData = {
 RMXScaler = {
 adjustSpace = 18;
@@ -91087,6 +91706,7 @@ height = 80;
 width = 81;
 };
 };
+width = 586;
 },
 {
 background = {
@@ -91136,7 +91756,6 @@ name = k.sc;
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 678;
 userData = {
 RMXScaler = {
 adjustSpace = 6;
@@ -91145,6 +91764,7 @@ weight = -17;
 width = 84;
 };
 };
+width = 678;
 },
 {
 background = {
@@ -91813,6 +92433,134 @@ leftKerningGroup = h.sc;
 rightKerningGroup = l.sc;
 },
 {
+color = 6;
+glyphname = aogonek.loclNAV.sc;
+layers = (
+{
+components = (
+{
+name = a.sc;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = UUID0;
+width = 563;
+},
+{
+components = (
+{
+name = a.sc;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 160, 0}";
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 702;
+},
+{
+background = {
+components = (
+{
+name = a.sc;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 326, 0}";
+}
+);
+};
+components = (
+{
+name = a.sc;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 86, 0}";
+}
+);
+guideLines = (
+{
+angle = 90;
+position = "{312, 321}";
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 624;
+}
+);
+leftKerningGroup = a.sc;
+rightKerningGroup = a.sc;
+},
+{
+color = 6;
+glyphname = eogonek.loclNAV.sc;
+layers = (
+{
+components = (
+{
+name = e.sc;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 60, 0}";
+}
+);
+layerId = UUID0;
+width = 559;
+},
+{
+components = (
+{
+name = e.sc;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 111, 0}";
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 588;
+},
+{
+background = {
+components = (
+{
+name = e.sc;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 226, 0}";
+}
+);
+};
+components = (
+{
+name = e.sc;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 86, 0}";
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 572;
+}
+);
+leftKerningGroup = h.sc;
+rightKerningGroup = e.sc;
+},
+{
 glyphname = lslash.sc;
 layers = (
 {
@@ -91844,7 +92592,6 @@ transform = "{1, 0, 0, 1, -21, -88}";
 }
 );
 layerId = UUID0;
-width = 486;
 userData = {
 RMXScaler = {
 adjustSpace = 18;
@@ -91852,6 +92599,7 @@ height = 80;
 width = 81;
 };
 };
+width = 486;
 },
 {
 anchors = (
@@ -91882,7 +92630,6 @@ transform = "{1, 0, 0, 1, -132, -64}";
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 543;
 userData = {
 RMXScaler = {
 adjustSpace = 6;
@@ -91891,6 +92638,7 @@ weight = -17;
 width = 84;
 };
 };
+width = 543;
 },
 {
 anchors = (
@@ -105927,13 +106675,13 @@ nodes = (
 );
 }
 );
-width = 895;
 userData = {
 RMXScaler = {
-height = 79.8000;
+height = 79.80000;
 width = 81;
 };
 };
+width = 895;
 },
 {
 anchors = (
@@ -106034,14 +106782,14 @@ nodes = (
 );
 }
 );
-width = 966;
 userData = {
 RMXScaler = {
-height = 83.2000;
+height = 83.20000;
 weight = -16;
 width = 86;
 };
 };
+width = 966;
 },
 {
 anchors = (
@@ -111796,6 +112544,193 @@ width = 967;
 );
 leftKerningGroup = h.sc;
 rightKerningGroup = h.sc;
+},
+{
+color = 6;
+glyphname = aogonek.loclNAV.sc.ss01;
+layers = (
+{
+components = (
+{
+name = a.sc.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 105, 0}";
+}
+);
+layerId = UUID0;
+width = 680;
+},
+{
+components = (
+{
+name = a.sc.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 144, 0}";
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 700;
+},
+{
+background = {
+components = (
+{
+name = a.sc.ss01;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 301, 0}";
+}
+);
+};
+components = (
+{
+name = a.sc.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 131, 0}";
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 688;
+}
+);
+leftKerningGroup = a.sc.ss01;
+rightKerningGroup = a.sc.ss01;
+},
+{
+color = 6;
+glyphname = eogonek.loclNAV.sc.ss01;
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 20, 0}";
+},
+{
+name = e.sc.ss01;
+}
+);
+layerId = UUID0;
+width = 519;
+},
+{
+components = (
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 111, 0}";
+},
+{
+name = e.sc.ss01;
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 606;
+},
+{
+background = {
+components = (
+{
+name = e.sc;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 226, 0}";
+}
+);
+};
+components = (
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 86, 0}";
+},
+{
+name = e.sc.ss01;
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 557;
+}
+);
+leftKerningGroup = e.sc.ss01;
+leftMetricsKey = e.sc.ss01;
+rightKerningGroup = e.sc.ss01;
+rightMetricsKey = e.sc.ss01;
+},
+{
+color = 6;
+glyphname = uogonek.loclNAV.sc.ss01;
+layers = (
+{
+components = (
+{
+name = u.sc.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 66, 0}";
+}
+);
+layerId = UUID0;
+width = 678;
+},
+{
+components = (
+{
+name = u.sc.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 53, 0}";
+}
+);
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+width = 701;
+},
+{
+background = {
+components = (
+{
+name = u.sc.ss01;
+},
+{
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 295, 0}";
+}
+);
+};
+components = (
+{
+name = u.sc.ss01;
+},
+{
+alignment = -1;
+name = ogonekcomb;
+transform = "{1, 0, 0, 1, 85, 0}";
+}
+);
+layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
+width = 688;
+}
+);
+leftKerningGroup = u.sc;
+leftMetricsKey = "=u.sc.ss01";
+rightKerningGroup = h.sc;
+rightMetricsKey = "=u.sc.ss01";
 },
 {
 color = 3;
@@ -152448,13 +153383,13 @@ nodes = (
 );
 }
 );
-width = 594;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 594;
 },
 {
 anchors = (
@@ -152573,14 +153508,14 @@ nodes = (
 );
 }
 );
-width = 629;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 629;
 },
 {
 anchors = (
@@ -152894,13 +153829,13 @@ nodes = (
 );
 }
 );
-width = 449;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 449;
 },
 {
 anchors = (
@@ -152960,14 +153895,14 @@ nodes = (
 );
 }
 );
-width = 543;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 543;
 },
 {
 anchors = (
@@ -153009,14 +153944,14 @@ nodes = (
 );
 }
 );
-width = 529;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 529;
 },
 {
 anchors = (
@@ -153057,13 +153992,13 @@ nodes = (
 );
 }
 );
-width = 458;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 458;
 },
 {
 anchors = (
@@ -153197,13 +154132,13 @@ nodes = (
 );
 }
 );
-width = 415;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 415;
 },
 {
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -153222,14 +154157,14 @@ nodes = (
 );
 }
 );
-width = 543;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 543;
 },
 {
 layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
@@ -153336,13 +154271,13 @@ nodes = (
 );
 }
 );
-width = 623;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 623;
 },
 {
 background = {
@@ -153416,14 +154351,14 @@ nodes = (
 );
 }
 );
-width = 746;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 746;
 },
 {
 layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
@@ -153764,13 +154699,13 @@ nodes = (
 );
 }
 );
-width = 779;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 779;
 },
 {
 anchors = (
@@ -153910,14 +154845,14 @@ nodes = (
 );
 }
 );
-width = 990;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 990;
 },
 {
 anchors = (
@@ -154113,13 +155048,13 @@ transform = "{-1, 0, 0, 1, 514, 0}";
 }
 );
 layerId = UUID0;
-width = 514;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 514;
 },
 {
 anchors = (
@@ -154190,14 +155125,14 @@ transform = "{-1, 0, 0, 1, 583, 0}";
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 583;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -29;
 width = 85;
 };
 };
+width = 583;
 },
 {
 anchors = (
@@ -154289,14 +155224,14 @@ nodes = (
 );
 }
 );
-width = 547;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -29;
 width = 85;
 };
 };
+width = 547;
 },
 {
 anchors = (
@@ -154384,13 +155319,13 @@ nodes = (
 );
 }
 );
-width = 674;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 674;
 },
 {
 anchors = (
@@ -154444,14 +155379,14 @@ nodes = (
 );
 }
 );
-width = 728;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -20;
 width = 85;
 };
 };
+width = 728;
 },
 {
 anchors = (
@@ -154775,13 +155710,13 @@ nodes = (
 );
 }
 );
-width = 548;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 548;
 },
 {
 anchors = (
@@ -154870,14 +155805,14 @@ nodes = (
 );
 }
 );
-width = 694;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 694;
 },
 {
 anchors = (
@@ -155065,13 +156000,13 @@ nodes = (
 );
 }
 );
-width = 613;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 613;
 },
 {
 anchors = (
@@ -155145,14 +156080,14 @@ nodes = (
 );
 }
 );
-width = 696;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 696;
 },
 {
 anchors = (
@@ -155284,14 +156219,14 @@ nodes = (
 );
 }
 );
-width = 695;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 695;
 },
 {
 anchors = (
@@ -155361,13 +156296,13 @@ nodes = (
 );
 }
 );
-width = 613;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 613;
 }
 );
 leftKerningGroup = "el-cy";
@@ -155422,13 +156357,13 @@ nodes = (
 );
 }
 );
-width = 775;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 775;
 },
 {
 anchors = (
@@ -155494,14 +156429,14 @@ nodes = (
 );
 }
 );
-width = 835;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -12;
 width = 85;
 };
 };
+width = 835;
 },
 {
 anchors = (
@@ -155565,14 +156500,14 @@ nodes = (
 );
 }
 );
-width = 813;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -12;
 width = 85;
 };
 };
+width = 813;
 },
 {
 anchors = (
@@ -155667,13 +156602,13 @@ nodes = (
 );
 }
 );
-width = 663;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 663;
 },
 {
 anchors = (
@@ -155714,14 +156649,14 @@ nodes = (
 );
 }
 );
-width = 710;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 710;
 },
 {
 anchors = (
@@ -155862,13 +156797,13 @@ nodes = (
 );
 }
 );
-width = 668;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 668;
 },
 {
 anchors = (
@@ -155912,14 +156847,14 @@ nodes = (
 );
 }
 );
-width = 693;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 693;
 },
 {
 anchors = (
@@ -156111,13 +157046,13 @@ nodes = (
 );
 }
 );
-width = 432;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 432;
 },
 {
 anchors = (
@@ -156156,14 +157091,14 @@ nodes = (
 );
 }
 );
-width = 583;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 583;
 },
 {
 anchors = (
@@ -156766,13 +157701,13 @@ nodes = (
 );
 }
 );
-width = 579;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 579;
 },
 {
 anchors = (
@@ -156856,14 +157791,14 @@ nodes = (
 );
 }
 );
-width = 662;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 662;
 },
 {
 anchors = (
@@ -156935,14 +157870,14 @@ nodes = (
 );
 }
 );
-width = 634;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 634;
 },
 {
 anchors = (
@@ -157071,13 +158006,13 @@ nodes = (
 );
 }
 );
-width = 672;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 672;
 },
 {
 anchors = (
@@ -157114,14 +158049,14 @@ nodes = (
 );
 }
 );
-width = 721;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 721;
 },
 {
 anchors = (
@@ -157204,13 +158139,13 @@ nodes = (
 );
 }
 );
-width = 903;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 903;
 },
 {
 anchors = (
@@ -157268,14 +158203,14 @@ nodes = (
 );
 }
 );
-width = 1005;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 1005;
 },
 {
 anchors = (
@@ -157371,13 +158306,13 @@ transform = "{1, 0, 0, 1, 697, 0}";
 }
 );
 layerId = UUID0;
-width = 903;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 903;
 },
 {
 background = {
@@ -157431,14 +158366,14 @@ transform = "{1, 0, 0, 1, 688, 0}";
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 1005;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 1005;
 },
 {
 components = (
@@ -157487,13 +158422,13 @@ nodes = (
 );
 }
 );
-width = 627;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 627;
 },
 {
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -157516,14 +158451,14 @@ nodes = (
 );
 }
 );
-width = 678;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 678;
 },
 {
 layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
@@ -157613,13 +158548,13 @@ nodes = (
 );
 }
 );
-width = 538;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 538;
 },
 {
 anchors = (
@@ -157709,14 +158644,14 @@ nodes = (
 );
 }
 );
-width = 639;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 639;
 },
 {
 anchors = (
@@ -157910,13 +158845,13 @@ nodes = (
 );
 }
 );
-width = 582;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 582;
 },
 {
 background = {
@@ -157995,14 +158930,14 @@ nodes = (
 );
 }
 );
-width = 730;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 730;
 },
 {
 background = {
@@ -158186,13 +159121,13 @@ nodes = (
 );
 }
 );
-width = 740;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 740;
 },
 {
 anchors = (
@@ -158283,14 +159218,14 @@ nodes = (
 );
 }
 );
-width = 920;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 920;
 },
 {
 anchors = (
@@ -158463,13 +159398,13 @@ transform = "{1, 0, 0, 1, 359, 0}";
 }
 );
 layerId = UUID0;
-width = 897;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 897;
 },
 {
 background = {
@@ -158526,14 +159461,14 @@ transform = "{1, 0, 0, 1, 364, 0}";
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 1003;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 1003;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -158625,14 +159560,14 @@ nodes = (
 );
 }
 );
-width = 958;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 958;
 },
 {
 associatedMasterId = UUID0;
@@ -158729,13 +159664,13 @@ nodes = (
 );
 }
 );
-width = 892;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 892;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -158825,14 +159760,14 @@ nodes = (
 );
 }
 );
-width = 953;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 953;
 },
 {
 associatedMasterId = UUID0;
@@ -158929,13 +159864,13 @@ nodes = (
 );
 }
 );
-width = 884;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 884;
 },
 {
 components = (
@@ -159039,13 +159974,13 @@ nodes = (
 );
 }
 );
-width = 928;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 928;
 },
 {
 background = {
@@ -159123,14 +160058,14 @@ nodes = (
 );
 }
 );
-width = 995;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 995;
 },
 {
 layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
@@ -159327,13 +160262,13 @@ nodes = (
 );
 }
 );
-width = 564;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 564;
 },
 {
 anchors = (
@@ -159391,14 +160326,14 @@ nodes = (
 );
 }
 );
-width = 610;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -30;
 width = 85;
 };
 };
+width = 610;
 },
 {
 anchors = (
@@ -159885,13 +160820,13 @@ nodes = (
 );
 }
 );
-width = 843;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 843;
 },
 {
 background = {
@@ -159995,14 +160930,14 @@ nodes = (
 );
 }
 );
-width = 934;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 934;
 },
 {
 layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
@@ -160162,13 +161097,13 @@ nodes = (
 );
 }
 );
-width = 594;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 594;
 },
 {
 background = {
@@ -160255,14 +161190,14 @@ nodes = (
 );
 }
 );
-width = 648;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 648;
 },
 {
 background = {
@@ -161086,13 +162021,13 @@ nodes = (
 );
 }
 );
-width = 632;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 632;
 },
 {
 background = {
@@ -161198,14 +162133,14 @@ nodes = (
 );
 }
 );
-width = 853;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -20;
 width = 85;
 };
 };
+width = 853;
 },
 {
 background = {
@@ -161367,13 +162302,13 @@ nodes = (
 );
 }
 );
-width = 650;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 650;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -161429,14 +162364,14 @@ nodes = (
 );
 }
 );
-width = 849;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -20;
 width = 85;
 };
 };
+width = 849;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -161544,14 +162479,14 @@ nodes = (
 );
 }
 );
-width = 853;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -20;
 width = 85;
 };
 };
+width = 853;
 }
 );
 leftKerningGroup = x;
@@ -161650,13 +162585,13 @@ nodes = (
 );
 }
 );
-width = 533;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 533;
 },
 {
 background = {
@@ -161703,14 +162638,14 @@ nodes = (
 );
 }
 );
-width = 709;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 84;
 };
 };
+width = 709;
 },
 {
 layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
@@ -161770,13 +162705,13 @@ nodes = (
 );
 }
 );
-width = 475;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 475;
 },
 {
 background = {
@@ -161810,14 +162745,14 @@ nodes = (
 );
 }
 );
-width = 589;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 589;
 },
 {
 components = (
@@ -162068,13 +163003,13 @@ transform = "{1, 0, 0, 1, 655, 0}";
 );
 layerId = UUID0;
 rightMetricsKey = "=+41";
-width = 820;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 820;
 },
 {
 background = {
@@ -162137,14 +163072,14 @@ transform = "{1, 0, 0, 1, 688, 0}";
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
 rightMetricsKey = "=+20";
-width = 1010;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -12;
 width = 85;
 };
 };
+width = 1010;
 },
 {
 components = (
@@ -162234,13 +163169,13 @@ transform = "{1, 0, 0, 1, 432, 0}";
 }
 );
 layerId = UUID0;
-width = 548;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 548;
 },
 {
 components = (
@@ -162253,14 +163188,14 @@ transform = "{1, 0, 0, 1, 395, 0}";
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 694;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -12;
 width = 85;
 };
 };
+width = 694;
 },
 {
 components = (
@@ -162338,13 +163273,13 @@ nodes = (
 );
 }
 );
-width = 563;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 563;
 },
 {
 background = {
@@ -162435,14 +163370,14 @@ nodes = (
 );
 }
 );
-width = 709;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -12;
 width = 85;
 };
 };
+width = 709;
 },
 {
 background = {
@@ -162648,13 +163583,13 @@ nodes = (
 );
 }
 );
-width = 549;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 549;
 },
 {
 anchors = (
@@ -162764,14 +163699,14 @@ nodes = (
 );
 }
 );
-width = 691;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 691;
 },
 {
 anchors = (
@@ -162996,13 +163931,13 @@ nodes = (
 );
 }
 );
-width = 597;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 597;
 },
 {
 anchors = (
@@ -163112,14 +164047,14 @@ nodes = (
 );
 }
 );
-width = 795;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -12;
 width = 85;
 };
 };
+width = 795;
 },
 {
 anchors = (
@@ -163252,13 +164187,13 @@ position = "{465, -114}";
 );
 layerId = UUID0;
 rightMetricsKey = "=+14";
-width = 677;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 677;
 },
 {
 components = (
@@ -163272,14 +164207,14 @@ transform = "{1, 0, 0, 1, 396, 0}";
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
 rightMetricsKey = "=+33";
-width = 743;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 743;
 },
 {
 components = (
@@ -163542,13 +164477,13 @@ transform = "{1, 0, 0, 1, 466, 0}";
 }
 );
 layerId = UUID0;
-width = 668;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 668;
 },
 {
 components = (
@@ -163561,14 +164496,14 @@ transform = "{1, 0, 0, 1, 379, 0}";
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 693;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 693;
 },
 {
 components = (
@@ -163824,13 +164759,13 @@ nodes = (
 );
 }
 );
-width = 771;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 771;
 },
 {
 background = {
@@ -163926,14 +164861,14 @@ nodes = (
 );
 }
 );
-width = 864;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 87;
 };
 };
+width = 864;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -164037,14 +164972,14 @@ nodes = (
 );
 }
 );
-width = 864;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 87;
 };
 };
+width = 864;
 },
 {
 background = {
@@ -164202,13 +165137,13 @@ transform = "{1, 0, 0, 1, 184, 0}";
 }
 );
 layerId = UUID0;
-width = 548;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 548;
 },
 {
 background = {
@@ -164266,14 +165201,14 @@ transform = "{1, 0, 0, 1, 165, 0}";
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 618;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 618;
 },
 {
 components = (
@@ -164700,13 +165635,13 @@ transform = "{1, 0, 0, 1, 371, 0}";
 }
 );
 layerId = UUID0;
-width = 495;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 495;
 },
 {
 background = {
@@ -164756,14 +165691,14 @@ transform = "{1, 0, 0, 1, 371, 0}";
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 657;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -12;
 width = 85;
 };
 };
+width = 657;
 },
 {
 components = (
@@ -164830,13 +165765,13 @@ nodes = (
 );
 }
 );
-width = 729;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 729;
 },
 {
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -164876,14 +165811,14 @@ nodes = (
 );
 }
 );
-width = 830;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 830;
 },
 {
 layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
@@ -164950,13 +165885,13 @@ transform = "{1, 0, 0, 1, 377, 0}";
 );
 layerId = UUID0;
 rightMetricsKey = "=+14";
-width = 593;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 593;
 },
 {
 background = {
@@ -165016,14 +165951,14 @@ transform = "{1, 0, 0, 1, 348, 0}";
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
 rightMetricsKey = "=+43";
-width = 705;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 705;
 },
 {
 components = (
@@ -166019,13 +166954,13 @@ nodes = (
 );
 }
 );
-width = 546;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 546;
 },
 {
 background = {
@@ -166145,14 +167080,14 @@ nodes = (
 );
 }
 );
-width = 694;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 694;
 },
 {
 anchors = (
@@ -166267,14 +167202,14 @@ nodes = (
 );
 }
 );
-width = 684;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 684;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -166383,14 +167318,14 @@ nodes = (
 );
 }
 );
-width = 687;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 687;
 },
 {
 associatedMasterId = UUID0;
@@ -166499,13 +167434,13 @@ nodes = (
 );
 }
 );
-width = 548;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 548;
 },
 {
 background = {
@@ -166631,13 +167566,13 @@ transform = "{1, 0, 0, 1, 396, 0}";
 );
 layerId = UUID0;
 rightMetricsKey = "=+15";
-width = 628;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 628;
 },
 {
 components = (
@@ -166652,14 +167587,14 @@ transform = "{1, 0, 0, 1, 379, 0}";
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
 rightMetricsKey = "=+33";
-width = 729;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 729;
 },
 {
 components = (
@@ -166815,13 +167750,13 @@ transform = "{1, 0, 0, 1, 446, 0}";
 );
 layerId = UUID0;
 rightMetricsKey = "=+15";
-width = 678;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 678;
 },
 {
 components = (
@@ -166836,14 +167771,14 @@ transform = "{1, 0, 0, 1, 394, 0}";
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
 rightMetricsKey = "=+34";
-width = 744;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 744;
 },
 {
 components = (
@@ -166953,13 +167888,13 @@ nodes = (
 );
 }
 );
-width = 578;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 578;
 },
 {
 background = {
@@ -167053,14 +167988,14 @@ nodes = (
 );
 }
 );
-width = 657;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 657;
 },
 {
 layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
@@ -167136,13 +168071,13 @@ transform = "{1, 0, 0, 1, 559, 0}";
 );
 layerId = UUID0;
 rightMetricsKey = "=+16";
-width = 791;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 791;
 },
 {
 background = {
@@ -167194,14 +168129,14 @@ transform = "{1, 0, 0, 1, 542, 0}";
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
 rightMetricsKey = "=+57";
-width = 892;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 892;
 },
 {
 components = (
@@ -168378,13 +169313,13 @@ transform = "{1, 0, 0, 1, 52, 0}";
 }
 );
 layerId = UUID0;
-width = 449;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 449;
 },
 {
 components = (
@@ -168398,14 +169333,14 @@ transform = "{1, 0, 0, 1, 17, 0}";
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 543;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 543;
 },
 {
 components = (
@@ -168881,13 +169816,13 @@ nodes = (
 );
 }
 );
-width = 489;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 489;
 },
 {
 background = {
@@ -168967,14 +169902,14 @@ nodes = (
 );
 }
 );
-width = 660;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 660;
 },
 {
 background = {
@@ -169162,13 +170097,13 @@ nodes = (
 );
 }
 );
-width = 493;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 493;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -169257,14 +170192,14 @@ nodes = (
 );
 }
 );
-width = 675;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 675;
 }
 );
 leftKerningGroup = x;
@@ -174393,13 +175328,13 @@ nodes = (
 );
 }
 );
-width = 544;
 userData = {
 RMXScaler = {
 height = 70;
 width = 90;
 };
 };
+width = 544;
 },
 {
 background = {
@@ -174477,13 +175412,13 @@ nodes = (
 );
 }
 );
-width = 631;
 userData = {
 RMXScaler = {
 height = 74;
 width = 90;
 };
 };
+width = 631;
 },
 {
 associatedMasterId = UUID0;
@@ -174577,13 +175512,13 @@ nodes = (
 );
 }
 );
-width = 604;
 userData = {
 RMXScaler = {
 height = 70;
 width = 90;
 };
 };
+width = 604;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -174673,13 +175608,13 @@ nodes = (
 );
 }
 );
-width = 627;
 userData = {
 RMXScaler = {
 height = 74;
 width = 90;
 };
 };
+width = 627;
 },
 {
 associatedMasterId = UUID0;
@@ -174769,13 +175704,13 @@ nodes = (
 );
 }
 );
-width = 561;
 userData = {
 RMXScaler = {
 height = 70;
 width = 90;
 };
 };
+width = 561;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -174855,13 +175790,13 @@ nodes = (
 );
 }
 );
-width = 614;
 userData = {
 RMXScaler = {
 height = 74;
 width = 90;
 };
 };
+width = 614;
 },
 {
 layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
@@ -178226,13 +179161,13 @@ nodes = (
 );
 }
 );
-width = 554;
 userData = {
 RMXScaler = {
 height = 70;
 width = 90;
 };
 };
+width = 554;
 },
 {
 background = {
@@ -178310,13 +179245,13 @@ nodes = (
 );
 }
 );
-width = 641;
 userData = {
 RMXScaler = {
 height = 74;
 width = 90;
 };
 };
+width = 641;
 },
 {
 associatedMasterId = UUID0;
@@ -178410,13 +179345,13 @@ nodes = (
 );
 }
 );
-width = 604;
 userData = {
 RMXScaler = {
 height = 70;
 width = 90;
 };
 };
+width = 604;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -178506,13 +179441,13 @@ nodes = (
 );
 }
 );
-width = 627;
 userData = {
 RMXScaler = {
 height = 74;
 width = 90;
 };
 };
+width = 627;
 },
 {
 associatedMasterId = UUID0;
@@ -178602,13 +179537,13 @@ nodes = (
 );
 }
 );
-width = 561;
 userData = {
 RMXScaler = {
 height = 70;
 width = 90;
 };
 };
+width = 561;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -178688,13 +179623,13 @@ nodes = (
 );
 }
 );
-width = 614;
 userData = {
 RMXScaler = {
 height = 74;
 width = 90;
 };
 };
+width = 614;
 },
 {
 layerId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
@@ -179132,13 +180067,13 @@ nodes = (
 );
 }
 );
-width = 740;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 740;
 },
 {
 anchors = (
@@ -179205,14 +180140,14 @@ nodes = (
 );
 }
 );
-width = 925;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 925;
 },
 {
 anchors = (
@@ -179400,13 +180335,13 @@ nodes = (
 );
 }
 );
-width = 908;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 908;
 },
 {
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -179474,14 +180409,14 @@ nodes = (
 );
 }
 );
-width = 1003;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 1003;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -179573,14 +180508,14 @@ nodes = (
 );
 }
 );
-width = 958;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 958;
 },
 {
 associatedMasterId = UUID0;
@@ -179677,13 +180612,13 @@ nodes = (
 );
 }
 );
-width = 892;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 892;
 },
 {
 associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
@@ -179773,14 +180708,14 @@ nodes = (
 );
 }
 );
-width = 953;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 953;
 },
 {
 associatedMasterId = UUID0;
@@ -179877,13 +180812,13 @@ nodes = (
 );
 }
 );
-width = 884;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 884;
 },
 {
 background = {
@@ -180075,13 +181010,13 @@ nodes = (
 );
 }
 );
-width = 918;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 918;
 },
 {
 background = {
@@ -180141,14 +181076,14 @@ nodes = (
 );
 }
 );
-width = 1003;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 1003;
 },
 {
 background = {
@@ -180323,14 +181258,14 @@ nodes = (
 );
 }
 );
-width = 995;
 userData = {
 RMXScaler = {
-height = 78.2000;
+height = 78.20000;
 weight = -7;
 width = 85;
 };
 };
+width = 995;
 },
 {
 associatedMasterId = "708134FE-A11E-43C9-84F0-594DA15B6BD1";
@@ -180456,13 +181391,13 @@ nodes = (
 );
 }
 );
-width = 928;
 userData = {
 RMXScaler = {
-height = 73.8000;
+height = 73.80000;
 width = 78;
 };
 };
+width = 928;
 }
 );
 leftKerningGroup = n;
@@ -205390,7 +206325,6 @@ nodes = (
 );
 }
 );
-width = 259;
 userData = {
 RMXScaler = {
 adjustSpace = 18;
@@ -205398,6 +206332,7 @@ height = 80;
 width = 81;
 };
 };
+width = 259;
 },
 {
 background = {
@@ -205429,7 +206364,6 @@ nodes = (
 );
 }
 );
-width = 344;
 userData = {
 RMXScaler = {
 adjustSpace = 6;
@@ -205438,6 +206372,7 @@ weight = -17;
 width = 84;
 };
 };
+width = 344;
 },
 {
 background = {
@@ -205798,7 +206733,6 @@ nodes = (
 );
 }
 );
-width = 507;
 userData = {
 RMXScaler = {
 adjustSpace = 18;
@@ -205806,6 +206740,7 @@ height = 89;
 width = 85;
 };
 };
+width = 507;
 },
 {
 background = {
@@ -205899,7 +206834,6 @@ nodes = (
 );
 }
 );
-width = 546;
 userData = {
 RMXScaler = {
 adjustSpace = 6;
@@ -205908,6 +206842,7 @@ weight = -17;
 width = 85;
 };
 };
+width = 546;
 },
 {
 background = {
@@ -206477,7 +207412,6 @@ transform = "{1, 0, 0, 1, 130, 0}";
 }
 );
 layerId = UUID0;
-width = 309;
 userData = {
 RMXScaler = {
 adjustSpace = 18;
@@ -206485,6 +207419,7 @@ height = 80;
 width = 81;
 };
 };
+width = 309;
 },
 {
 background = {
@@ -206508,7 +207443,6 @@ transform = "{1, 0, 0, 1, 290, 0}";
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 594;
 userData = {
 RMXScaler = {
 adjustSpace = 6;
@@ -206517,6 +207451,7 @@ weight = -17;
 width = 84;
 };
 };
+width = 594;
 },
 {
 background = {
@@ -206578,7 +207513,6 @@ transform = "{1, 0, 0, 1, 130, 0}";
 }
 );
 layerId = UUID0;
-width = 309;
 userData = {
 RMXScaler = {
 adjustSpace = 18;
@@ -206586,6 +207520,7 @@ height = 80;
 width = 81;
 };
 };
+width = 309;
 },
 {
 background = {
@@ -206609,7 +207544,6 @@ transform = "{1, 0, 0, 1, 290, 0}";
 }
 );
 layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
-width = 594;
 userData = {
 RMXScaler = {
 adjustSpace = 6;
@@ -206618,6 +207552,7 @@ weight = -17;
 width = 84;
 };
 };
+width = 594;
 },
 {
 background = {
@@ -206708,7 +207643,6 @@ nodes = (
 );
 }
 );
-width = 179;
 userData = {
 RMXScaler = {
 adjustSpace = 18;
@@ -206716,6 +207650,7 @@ height = 80;
 width = 81;
 };
 };
+width = 179;
 },
 {
 background = {
@@ -206767,7 +207702,6 @@ nodes = (
 );
 }
 );
-width = 304;
 userData = {
 RMXScaler = {
 adjustSpace = 6;
@@ -206776,6 +207710,7 @@ weight = -17;
 width = 84;
 };
 };
+width = 304;
 },
 {
 background = {
@@ -206894,7 +207829,6 @@ nodes = (
 );
 }
 );
-width = 179;
 userData = {
 RMXScaler = {
 adjustSpace = 18;
@@ -206902,6 +207836,7 @@ height = 80;
 width = 81;
 };
 };
+width = 179;
 },
 {
 background = {
@@ -206953,7 +207888,6 @@ nodes = (
 );
 }
 );
-width = 304;
 userData = {
 RMXScaler = {
 adjustSpace = 6;
@@ -206962,6 +207896,7 @@ weight = -17;
 width = 84;
 };
 };
+width = 304;
 },
 {
 background = {
@@ -232082,7 +233017,6 @@ nodes = (
 );
 }
 );
-width = 515;
 userData = {
 RMXScaler = {
 adjustSpace = 18;
@@ -232090,6 +233024,7 @@ height = 80;
 width = 81;
 };
 };
+width = 515;
 },
 {
 background = {
@@ -232201,7 +233136,6 @@ nodes = (
 );
 }
 );
-width = 664;
 userData = {
 RMXScaler = {
 adjustSpace = 6;
@@ -232210,6 +233144,7 @@ weight = -17;
 width = 84;
 };
 };
+width = 664;
 },
 {
 background = {
@@ -244990,12 +245925,12 @@ nodes = (
 );
 }
 );
-width = 600;
 userData = {
 RMXScaler = {
 weight = -20;
 };
 };
+width = 600;
 },
 {
 anchors = (
@@ -245152,12 +246087,12 @@ nodes = (
 );
 }
 );
-width = 600;
 userData = {
 RMXScaler = {
 weight = -20;
 };
 };
+width = 600;
 },
 {
 anchors = (
@@ -246230,7 +247165,6 @@ nodes = (
 );
 }
 );
-width = 600;
 userData = {
 RMXScaler = {
 height = 90;
@@ -246238,6 +247172,7 @@ weight = 3;
 width = 95;
 };
 };
+width = 600;
 },
 {
 anchors = (
@@ -246317,7 +247252,6 @@ nodes = (
 );
 }
 );
-width = 600;
 userData = {
 RMXScaler = {
 height = 75;
@@ -246325,6 +247259,7 @@ weight = 5;
 width = 90;
 };
 };
+width = 600;
 },
 {
 anchors = (
@@ -247312,12 +248247,12 @@ nodes = (
 );
 }
 );
-width = 600;
 userData = {
 RMXScaler = {
 width = 80;
 };
 };
+width = 600;
 },
 {
 anchors = (
@@ -247397,13 +248332,13 @@ nodes = (
 );
 }
 );
-width = 600;
 userData = {
 RMXScaler = {
 weight = 10;
 width = 90;
 };
 };
+width = 600;
 },
 {
 anchors = (
@@ -254112,8 +255047,8 @@ value = AddExtremes;
 );
 interpolationWeight = 33;
 instanceInterpolations = {
-UUID0 = 0.855556;
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.144444;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.14444;
+UUID0 = 0.85556;
 };
 name = ExtraLight;
 weightClass = ExtraLight;
@@ -254131,8 +255066,8 @@ value = AddExtremes;
 );
 interpolationWeight = 50;
 instanceInterpolations = {
-UUID0 = 0.666667;
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.333333;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.33333;
+UUID0 = 0.66667;
 };
 name = Light;
 weightClass = Light;
@@ -254150,8 +255085,8 @@ value = AddExtremes;
 );
 interpolationWeight = 71;
 instanceInterpolations = {
-UUID0 = 0.433333;
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.566667;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.56667;
+UUID0 = 0.43333;
 };
 name = Regular;
 },
@@ -254168,8 +255103,8 @@ value = AddExtremes;
 );
 interpolationWeight = 96;
 instanceInterpolations = {
-UUID0 = 0.155556;
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.844444;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.84444;
+UUID0 = 0.15556;
 };
 name = Medium;
 weightClass = Medium;
@@ -254187,8 +255122,8 @@ value = AddExtremes;
 );
 interpolationWeight = 125;
 instanceInterpolations = {
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.87069;
 "5DA6E103-6A94-47F2-987D-4952DB8EA68E" = 0.12931;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.87069;
 };
 name = SemiBold;
 weightClass = SemiBold;
@@ -254206,8 +255141,8 @@ value = AddExtremes;
 );
 interpolationWeight = 156;
 instanceInterpolations = {
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.603448;
-"5DA6E103-6A94-47F2-987D-4952DB8EA68E" = 0.396552;
+"5DA6E103-6A94-47F2-987D-4952DB8EA68E" = 0.39655;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.60345;
 };
 isBold = 1;
 name = Bold;
@@ -254226,8 +255161,8 @@ value = AddExtremes;
 );
 interpolationWeight = 190;
 instanceInterpolations = {
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.310345;
-"5DA6E103-6A94-47F2-987D-4952DB8EA68E" = 0.689655;
+"5DA6E103-6A94-47F2-987D-4952DB8EA68E" = 0.68966;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.31034;
 };
 name = ExtraBold;
 weightClass = ExtraBold;
@@ -256169,8 +257104,8 @@ Udieresis.ss01.alt
 );
 interpolationWeight = 33;
 instanceInterpolations = {
-UUID0 = 0.855556;
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.144444;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.14444;
+UUID0 = 0.85556;
 };
 name = ExtraLight;
 weightClass = ExtraLight;
@@ -257130,8 +258065,8 @@ Udieresis.ss01.alt
 );
 interpolationWeight = 50;
 instanceInterpolations = {
-UUID0 = 0.666667;
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.333333;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.33333;
+UUID0 = 0.66667;
 };
 name = Light;
 weightClass = Light;
@@ -258091,8 +259026,8 @@ Udieresis.ss01.alt
 );
 interpolationWeight = 71;
 instanceInterpolations = {
-UUID0 = 0.433333;
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.566667;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.56667;
+UUID0 = 0.43333;
 };
 name = Regular;
 },
@@ -259051,8 +259986,8 @@ Udieresis.ss01.alt
 );
 interpolationWeight = 96;
 instanceInterpolations = {
-UUID0 = 0.155556;
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.844444;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.84444;
+UUID0 = 0.15556;
 };
 name = Medium;
 weightClass = Medium;
@@ -260012,8 +260947,8 @@ Udieresis.ss01.alt
 );
 interpolationWeight = 125;
 instanceInterpolations = {
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.87069;
 "5DA6E103-6A94-47F2-987D-4952DB8EA68E" = 0.12931;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.87069;
 };
 name = SemiBold;
 weightClass = SemiBold;
@@ -260973,8 +261908,8 @@ Udieresis.ss01.alt
 );
 interpolationWeight = 156;
 instanceInterpolations = {
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.603448;
-"5DA6E103-6A94-47F2-987D-4952DB8EA68E" = 0.396552;
+"5DA6E103-6A94-47F2-987D-4952DB8EA68E" = 0.39655;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.60345;
 };
 isBold = 1;
 name = Bold;
@@ -261935,8 +262870,8 @@ Udieresis.ss01.alt
 );
 interpolationWeight = 190;
 instanceInterpolations = {
-"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.310345;
-"5DA6E103-6A94-47F2-987D-4952DB8EA68E" = 0.689655;
+"5DA6E103-6A94-47F2-987D-4952DB8EA68E" = 0.68966;
+"708134FE-A11E-43C9-84F0-594DA15B6BD1" = 0.31034;
 };
 name = ExtraBold;
 weightClass = ExtraBold;


### PR DESCRIPTION
In Navajo typesetting, the ogonek accent should be placed in the middle.
I’ll add similar forms to the Italic font once you’ve had a look and
have confirmed that you’d actually accept this change.

Perhaps GitHub user @nv-wiki could have a look at the letterforms
to confirm they make sense for the Navajo language.

![image](https://user-images.githubusercontent.com/1527880/33822416-bf2f7338-de57-11e7-87ba-870725b934b9.png)
